### PR TITLE
There is an error in Program class, wrong variable is used in for loop

### DIFF
--- a/src/kjscompiler/Program.java
+++ b/src/kjscompiler/Program.java
@@ -166,7 +166,7 @@ public class Program {
 		if (errors.length == 0) {
 			JSError[] warnings = compiler.getWarnings();
 			for (int i = 0, length = warnings.length; i < length; i++) {
-				JSError warn = errors[i];
+				JSError warn = warnings[i];
 				System.out.println("Warning #" + (i + 1) + ": "
 						+ warn.description + " in " + warn.sourceName + " ("
 						+ warn.lineNumber + ")");


### PR DESCRIPTION
Iteration goes from 0 to warnings.length, but errors[i] is used instead of warnings[i], which sometimes causes an index out of bounds exception.
